### PR TITLE
:bug: Write the position to the right characteristic

### DIFF
--- a/src/helper/motionMount.ts
+++ b/src/helper/motionMount.ts
@@ -82,16 +82,28 @@ export async function moveToPosition(
 
   try {
     log.info('[moveToPosition] Getting characteristics ...');
-    const {
-      characteristics: [setPositionCharacteristic],
-    } = await peripheral.discoverSomeServicesAndCharacteristicsAsync(
-      [],
-      [MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID],
-    );
+    const { characteristics } =
+      await peripheral.discoverSomeServicesAndCharacteristicsAsync(
+        [],
+        [MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID],
+      );
 
+    // The macOS binding ignores the characteristic filter and returns the whole
+    // service, so never rely on the returned order: match the uuid explicitly.
+    const setPositionCharacteristic = characteristics.find(
+      ({ uuid }) => uuid === MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID,
+    );
+    if (!setPositionCharacteristic) {
+      throw new Error(
+        `Characteristic ${MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID} not found`,
+      );
+    }
+
+    // The characteristic only advertises `write` (with response); writing it
+    // without response is silently dropped by CoreBluetooth on macOS.
     await setPositionCharacteristic.writeAsync(
       Buffer.from(positionPreset.hexPosition, 'hex'),
-      true,
+      false,
     );
   } catch (err) {
     log.error('[moveToPosition]', toError(err).message);


### PR DESCRIPTION
The plugin never actually moved the mount on macOS. Two bugs in `moveToPosition`, both found while testing the plugin locally against a real Vogel's MotionMount.

### 1. The wrong characteristic was written

`moveToPosition` trusted `discoverSomeServicesAndCharacteristics` to return only the requested characteristic, and destructured index 0 out of the result:

```ts
const { characteristics: [setPositionCharacteristic] } =
  await peripheral.discoverSomeServicesAndCharacteristicsAsync([], [SET_POSITION_UUID]);
```

With an empty service filter the characteristic filter is not applied by the macOS binding — it returns the whole service, all 37 characteristics:

```
discoverSome([], ['c005fa21…']) -> #characteristics = 37
  [0]  c005fa00…  [read,write,notify]   <- what was picked up
  [33] c005fa21…  [write]               <- the actual set-position characteristic
```

So a 4-byte position payload was written to `c005fa00`, the 2-byte *current distance* register. Now matched by uuid explicitly, with an explicit error if it is missing.

### 2. The wrong write type

`c005fa21` only advertises `write` (with response), but the call asked for `writeWithoutResponse`. CoreBluetooth drops those silently and noble resolves the promise immediately without an ack, so the failure looked like a successful 3 ms write with no error logged — which is what hid both bugs.

### Scope

Both are latent on Linux: BlueZ applies the service-level filter and tolerates a write-without-response on this characteristic, which is why the plugin works on Raspberry Pi. Neither is a regression from the recent toolchain modernization — the `[setPositionCharacteristic]` destructuring and the `true` argument predate it.

### Verification

Tested on macOS against a real mount, reading the live position characteristics (`c005fa00` / `c005fa01`) on a separate connection while the plugin code drives the move:

```
BEFORE  distance =  10, rotation =   0
T+3s    distance =  22, rotation = -15
T+9s    distance =  62, rotation = -62
T+15s   distance = 100, rotation = -99   <- target 0x0064ff9c = (100, -100)
```

Presets are read correctly too (6 found), and the mount was driven to two different presets and back to the wall. Physically confirmed.

`pnpm build`, `pnpm typecheck` and `pnpm lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)