### PR TITLE
:bug: Recover from dropped Bluetooth connections

### DIFF
--- a/src/helper/motionMount.ts
+++ b/src/helper/motionMount.ts
@@ -26,6 +26,18 @@ const WRITE_TIMEOUT_MS = 30_000;
 const MAX_ATTEMPTS = 2;
 const RETRY_DELAY_MS = 5_000;
 
+// noble asks for a 420ms supervision timeout, which tears the link down as soon
+// as a fraction of a second of packets goes missing — routine at the edge of
+// range, where an HCI trace showed the mount dropping the moment discovery
+// started. Ask for 4s instead (the field counts 10ms units), comfortably above
+// the 45ms floor implied by noble's connection interval. Linux only: the macOS
+// binding negotiates its own parameters and ignores these.
+const CONNECTION_PARAMETERS = { timeout: 400 };
+
+type ConnectWithParameters = (
+  parameters?: Record<string, number>,
+) => Promise<void>;
+
 export interface PositionPreset {
   label: string;
   hexPosition: string;
@@ -117,7 +129,7 @@ async function stopScanning(log: Logging): Promise<void> {
 export async function detectFirstMotionMountPeripheral(
   log: Logging,
 ): Promise<Peripheral> {
-  log.info('[detectFirstMotionMountPeripheral] Removing discover listeners');
+  log.debug('[detectFirstMotionMountPeripheral] Removing discover listeners');
   noble.removeAllListeners('discover');
 
   const discovery = new Promise<Peripheral>((resolve, reject) => {
@@ -127,7 +139,7 @@ export async function detectFirstMotionMountPeripheral(
       );
       void stopScanning(log).finally(() => resolve(peripheral));
     });
-    log.info('[detectFirstMotionMountPeripheral] Starting scan');
+    log.debug('[detectFirstMotionMountPeripheral] Starting scan');
     noble
       .startScanningAsync([MOTION_MOUNT_SERVICE_UUID], false)
       .catch((err: unknown) => {
@@ -191,7 +203,7 @@ async function releasePeripheral(log: Logging, reason: string): Promise<void> {
   lastPeripheral = null;
   if (!peripheral) return;
 
-  log.info('[releasePeripheral]', reason);
+  log.debug('[releasePeripheral]', reason);
   // Disconnecting one that is already down just hangs until the timeout.
   if (peripheral.state !== 'disconnected') {
     try {
@@ -201,7 +213,10 @@ async function releasePeripheral(log: Logging, reason: string): Promise<void> {
         'Disconnect',
       );
     } catch (err) {
-      log.warn('[releasePeripheral] Failed to disconnect', toError(err).message);
+      log.warn(
+        '[releasePeripheral] Failed to disconnect',
+        toError(err).message,
+      );
     }
   }
   forgetInNoble(peripheral);
@@ -209,7 +224,7 @@ async function releasePeripheral(log: Logging, reason: string): Promise<void> {
 
 async function getPeripheral(log: Logging): Promise<Peripheral> {
   if (!peripheralInstance) {
-    log.info('[getPeripheral] Detecting peripheral ...');
+    log.debug('[getPeripheral] Detecting peripheral ...');
     const peripheral = await detectFirstMotionMountPeripheral(log);
     peripheral.once('disconnect', () => {
       // Stay quiet when we are the ones who just let go of it.
@@ -219,18 +234,22 @@ async function getPeripheral(log: Logging): Promise<Peripheral> {
     });
     peripheralInstance = peripheral;
     lastPeripheral = peripheral;
-    log.info('[getPeripheral] Peripheral detected');
+    log.debug('[getPeripheral] Peripheral detected');
   }
 
   if (peripheralInstance.state === 'connected') {
-    log.info('[getPeripheral] Already connected, returning as is');
+    log.debug('[getPeripheral] Already connected, returning as is');
     return peripheralInstance;
   }
 
-  log.info('[getPeripheral] Connecting ...');
+  log.debug('[getPeripheral] Connecting ...');
+  // `connectAsync` does forward connection parameters, it is only the bundled
+  // types that stop at the no-argument form.
+  const connect: ConnectWithParameters =
+    peripheralInstance.connectAsync.bind(peripheralInstance);
   await whileLinkHolds(
     peripheralInstance,
-    peripheralInstance.connectAsync(),
+    connect(CONNECTION_PARAMETERS),
     CONNECT_TIMEOUT_MS,
     'Connect',
   );
@@ -294,7 +313,7 @@ async function writePosition(
 ): Promise<void> {
   const peripheral = await getPeripheral(log);
 
-  log.info('[moveToPosition] Getting characteristics ...');
+  log.debug('[moveToPosition] Getting characteristics ...');
   const { characteristics } = await whileLinkHolds(
     peripheral,
     peripheral.discoverSomeServicesAndCharacteristicsAsync(
@@ -406,7 +425,7 @@ async function readPositionPresets(log: Logging): Promise<PositionPreset[]> {
 export async function retrievePositionPresets(
   log: Logging,
 ): Promise<PositionPreset[]> {
-  log.info('[retrievedStoredPositions] Starting the retrieval');
+  log.debug('[retrievedStoredPositions] Starting the retrieval');
   return serialise(async () => {
     try {
       return await withRetry('retrievedStoredPositions', log, () =>

--- a/src/helper/motionMount.ts
+++ b/src/helper/motionMount.ts
@@ -36,6 +36,11 @@ export const WALL_POSITION: PositionPreset = {
   hexPosition: '00000000',
 };
 
+let mountQueue: Promise<unknown> = Promise.resolve();
+// Only the last position asked for matters: the ones queued behind it would
+// drive the mount somewhere the user has already moved on from.
+let requestedPreset: PositionPreset | null = null;
+
 let peripheralInstance: Peripheral | null;
 // The disconnect handler clears `peripheralInstance` on its own, which would
 // leave the cleanup below with nothing to work on. Keep the last peripheral we
@@ -236,6 +241,23 @@ async function getPeripheral(log: Logging): Promise<Peripheral> {
   return peripheralInstance;
 }
 
+/**
+ * Run one conversation with the mount at a time.
+ *
+ * Concurrent calls trample each other: the scan listener is global, so one scan
+ * unregisters another's, and an operation releasing the connection pulls it
+ * from under its neighbour. Nothing is gained by overlapping them either — a
+ * single radio talks to a single mount.
+ */
+function serialise<T>(action: () => Promise<T>): Promise<T> {
+  const result = mountQueue.then(action, action);
+  mountQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
 async function withRetry<T>(
   label: string,
   log: Logging,
@@ -312,14 +334,24 @@ export async function moveToPosition(
   positionPreset: PositionPreset,
   log: Logging,
 ): Promise<void> {
-  log.info('[moveToPosition] Going to', positionPreset.label);
-  try {
-    await withRetry('moveToPosition', log, () =>
-      writePosition(positionPreset, log),
-    );
-  } finally {
-    await releasePeripheral(log, 'Move done, releasing the connection');
-  }
+  requestedPreset = positionPreset;
+  log.info('[moveToPosition] Requested', positionPreset.label);
+
+  return serialise(async () => {
+    const target = requestedPreset;
+    requestedPreset = null;
+    if (!target) {
+      log.info('[moveToPosition] Superseded by a newer request, skipping');
+      return;
+    }
+
+    log.info('[moveToPosition] Going to', target.label);
+    try {
+      await withRetry('moveToPosition', log, () => writePosition(target, log));
+    } finally {
+      await releasePeripheral(log, 'Move done, releasing the connection');
+    }
+  });
 }
 
 async function readPositionPresets(log: Logging): Promise<PositionPreset[]> {
@@ -375,11 +407,13 @@ export async function retrievePositionPresets(
   log: Logging,
 ): Promise<PositionPreset[]> {
   log.info('[retrievedStoredPositions] Starting the retrieval');
-  try {
-    return await withRetry('retrievedStoredPositions', log, () =>
-      readPositionPresets(log),
-    );
-  } finally {
-    await releasePeripheral(log, 'Presets read, releasing the connection');
-  }
+  return serialise(async () => {
+    try {
+      return await withRetry('retrievedStoredPositions', log, () =>
+        readPositionPresets(log),
+      );
+    } finally {
+      await releasePeripheral(log, 'Presets read, releasing the connection');
+    }
+  });
 }

--- a/src/helper/motionMount.ts
+++ b/src/helper/motionMount.ts
@@ -5,6 +5,18 @@ const MOTION_MOUNT_SERVICE_UUID = '3e6fe65ded7811e4895e00026fd5c52c';
 const MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID =
   'c005fa2106514800b000000000000000';
 
+// noble never times out on its own, so a request issued over a dead link hangs
+// forever and wedges every later call. These bounds exist to break that
+// deadlock, not to enforce responsiveness: a mount sitting at the edge of range
+// (a Raspberry Pi a few rooms away reports around -85 dBm) routinely needs 40s
+// just to connect, so they are deliberately loose.
+const SCAN_TIMEOUT_MS = 30_000;
+const CONNECT_TIMEOUT_MS = 90_000;
+const DISCONNECT_TIMEOUT_MS = 10_000;
+const DISCOVER_TIMEOUT_MS = 60_000;
+const READ_TIMEOUT_MS = 30_000;
+const WRITE_TIMEOUT_MS = 30_000;
+
 export interface PositionPreset {
   label: string;
   hexPosition: string;
@@ -21,26 +33,47 @@ function toError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err));
 }
 
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function stopScanning(log: Logging): Promise<void> {
+  try {
+    await noble.stopScanningAsync();
+  } catch (err) {
+    log.warn('[stopScanning] Failed to stop scan', toError(err).message);
+  }
+}
+
 export async function detectFirstMotionMountPeripheral(
   log: Logging,
 ): Promise<Peripheral> {
   log.info('[detectFirstMotionMountPeripheral] Removing discover listeners');
   noble.removeAllListeners('discover');
 
-  return new Promise<Peripheral>((resolve, reject) => {
+  const discovery = new Promise<Peripheral>((resolve, reject) => {
     noble.on('discover', (peripheral: Peripheral) => {
       log.info(
         '[detectFirstMotionMountPeripheral] Peripheral discovered, stopping scan',
       );
-      noble
-        .stopScanningAsync()
-        .catch((err: unknown) =>
-          log.warn(
-            '[detectFirstMotionMountPeripheral] Failed to stop scan',
-            toError(err).message,
-          ),
-        )
-        .finally(() => resolve(peripheral));
+      void stopScanning(log).finally(() => resolve(peripheral));
     });
     log.info('[detectFirstMotionMountPeripheral] Starting scan');
     noble
@@ -50,12 +83,47 @@ export async function detectFirstMotionMountPeripheral(
         reject(toError(err));
       });
   });
+
+  try {
+    return await withTimeout(discovery, SCAN_TIMEOUT_MS, 'Scan');
+  } catch (err) {
+    // A scan left running keeps the adapter busy and starves the next attempt.
+    noble.removeAllListeners('discover');
+    await stopScanning(log);
+    throw toError(err);
+  }
+}
+
+/**
+ * Forget the cached peripheral so the next call rediscovers from scratch.
+ * Disconnecting is best effort: the link is usually already gone by then.
+ */
+async function resetPeripheral(log: Logging): Promise<void> {
+  const peripheral = peripheralInstance;
+  peripheralInstance = null;
+  if (!peripheral) return;
+
+  log.info('[resetPeripheral] Dropping the cached peripheral');
+  try {
+    await withTimeout(
+      peripheral.disconnectAsync(),
+      DISCONNECT_TIMEOUT_MS,
+      'Disconnect',
+    );
+  } catch (err) {
+    log.warn('[resetPeripheral] Failed to disconnect', toError(err).message);
+  }
 }
 
 async function getPeripheral(log: Logging): Promise<Peripheral> {
   if (!peripheralInstance) {
     log.info('[getPeripheral] Detecting peripheral ...');
-    peripheralInstance = await detectFirstMotionMountPeripheral(log);
+    const peripheral = await detectFirstMotionMountPeripheral(log);
+    peripheral.once('disconnect', () => {
+      log.info('[getPeripheral] Peripheral disconnected, dropping it');
+      if (peripheralInstance === peripheral) peripheralInstance = null;
+    });
+    peripheralInstance = peripheral;
     log.info('[getPeripheral] Peripheral detected');
   }
 
@@ -65,7 +133,11 @@ async function getPeripheral(log: Logging): Promise<Peripheral> {
   }
 
   log.info('[getPeripheral] Connecting ...');
-  await peripheralInstance.connectAsync();
+  await withTimeout(
+    peripheralInstance.connectAsync(),
+    CONNECT_TIMEOUT_MS,
+    'Connect',
+  );
   log.info(
     '[getPeripheral] Connection established, rssi =',
     peripheralInstance.rssi,
@@ -78,15 +150,19 @@ export async function moveToPosition(
   log: Logging,
 ): Promise<void> {
   log.info('[moveToPosition] Going to', positionPreset.label);
-  const peripheral = await getPeripheral(log);
 
   try {
+    const peripheral = await getPeripheral(log);
+
     log.info('[moveToPosition] Getting characteristics ...');
-    const { characteristics } =
-      await peripheral.discoverSomeServicesAndCharacteristicsAsync(
+    const { characteristics } = await withTimeout(
+      peripheral.discoverSomeServicesAndCharacteristicsAsync(
         [],
         [MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID],
-      );
+      ),
+      DISCOVER_TIMEOUT_MS,
+      'Characteristic discovery',
+    );
 
     // The macOS binding ignores the characteristic filter and returns the whole
     // service, so never rely on the returned order: match the uuid explicitly.
@@ -101,12 +177,23 @@ export async function moveToPosition(
 
     // The characteristic only advertises `write` (with response); writing it
     // without response is silently dropped by CoreBluetooth on macOS.
-    await setPositionCharacteristic.writeAsync(
-      Buffer.from(positionPreset.hexPosition, 'hex'),
-      false,
+    await withTimeout(
+      setPositionCharacteristic.writeAsync(
+        Buffer.from(positionPreset.hexPosition, 'hex'),
+        false,
+      ),
+      WRITE_TIMEOUT_MS,
+      'Position write',
     );
+    log.info('[moveToPosition] Position written');
   } catch (err) {
-    log.error('[moveToPosition]', toError(err).message);
+    const error = toError(err);
+    log.error('[moveToPosition]', error.message);
+    // Whatever failed, the link can no longer be trusted. Start over on the
+    // next call instead of piling requests onto a half-dead connection, and let
+    // the caller report the failure rather than pretending the mount moved.
+    await resetPeripheral(log);
+    throw error;
   }
 }
 
@@ -114,41 +201,59 @@ export async function retrievePositionPresets(
   log: Logging,
 ): Promise<PositionPreset[]> {
   log.info('[retrievedStoredPositions] Starting the retrieval');
-  const peripheral = await getPeripheral(log);
-  const { characteristics } =
-    await peripheral.discoverAllServicesAndCharacteristicsAsync();
-  // Omitting `2a00-2a05` retrieved by some devices
-  const normalizedCharacteristics = characteristics.filter(({ uuid }) =>
-    uuid.startsWith('c005fa'),
-  );
 
-  const positionPresets: PositionPreset[] = [WALL_POSITION];
-  // Characteristics (#10-19 + #23-32) are the first part of the preset (+ 13 offset for the 2nd part)
-  const presetIndexOffset = 13;
-  const presetStartingIndex = 10;
-  const presetEndingIndex = 19;
-  for (
-    let index = presetStartingIndex;
-    index <= presetEndingIndex;
-    index += 1
-  ) {
-    const [presetPartOne, presetPartTwo] = await Promise.all([
-      normalizedCharacteristics[index].readAsync(),
-      normalizedCharacteristics[index + presetIndexOffset].readAsync(),
-    ]);
-    const presetHex =
-      presetPartOne.toString('hex') + presetPartTwo.toString('hex');
+  try {
+    const peripheral = await getPeripheral(log);
+    const { characteristics } = await withTimeout(
+      peripheral.discoverAllServicesAndCharacteristicsAsync(),
+      DISCOVER_TIMEOUT_MS,
+      'Service discovery',
+    );
+    // Omitting `2a00-2a05` retrieved by some devices
+    const normalizedCharacteristics = characteristics.filter(({ uuid }) =>
+      uuid.startsWith('c005fa'),
+    );
 
-    // First two chars for active/inactive preset (01: active, 00: inactive)
-    if (presetHex.slice(0, 2) === '01') {
-      positionPresets.push({
-        // 2-9 chars contain the position (2-5 hex signed wall distance and 6-9 hex signed orientation)
-        hexPosition: presetHex.slice(2, 10),
-        // 10-end contain the utf8 preset label
-        label: Buffer.from(presetHex.substring(10), 'hex').toString('utf8'),
-      });
+    const positionPresets: PositionPreset[] = [WALL_POSITION];
+    // Characteristics (#10-19 + #23-32) are the first part of the preset (+ 13 offset for the 2nd part)
+    const presetIndexOffset = 13;
+    const presetStartingIndex = 10;
+    const presetEndingIndex = 19;
+    for (
+      let index = presetStartingIndex;
+      index <= presetEndingIndex;
+      index += 1
+    ) {
+      const [presetPartOne, presetPartTwo] = await withTimeout(
+        Promise.all([
+          normalizedCharacteristics[index].readAsync(),
+          normalizedCharacteristics[index + presetIndexOffset].readAsync(),
+        ]),
+        READ_TIMEOUT_MS,
+        `Preset #${index} read`,
+      );
+      const presetHex =
+        presetPartOne.toString('hex') + presetPartTwo.toString('hex');
+
+      // First two chars for active/inactive preset (01: active, 00: inactive)
+      if (presetHex.slice(0, 2) === '01') {
+        positionPresets.push({
+          // 2-9 chars contain the position (2-5 hex signed wall distance and 6-9 hex signed orientation)
+          hexPosition: presetHex.slice(2, 10),
+          // 10-end contain the utf8 preset label
+          label: Buffer.from(presetHex.substring(10), 'hex').toString('utf8'),
+        });
+      }
     }
+    log.info(
+      '[retrievedStoredPositions] #Presets found',
+      positionPresets.length,
+    );
+    return positionPresets;
+  } catch (err) {
+    const error = toError(err);
+    log.error('[retrievedStoredPositions]', error.message);
+    await resetPeripheral(log);
+    throw error;
   }
-  log.info('[retrievedStoredPositions] #Presets found', positionPresets.length);
-  return positionPresets;
 }

--- a/src/helper/motionMount.ts
+++ b/src/helper/motionMount.ts
@@ -169,16 +169,24 @@ function forgetInNoble(peripheral: Peripheral): void {
 }
 
 /**
- * Forget the cached peripheral so the next call rediscovers from scratch.
- * Disconnecting is best effort: the link is usually already gone by then.
+ * Let go of the connection so the next call starts from a fresh discovery.
+ * Disconnecting is best effort: the link is often already gone by then.
+ *
+ * Nothing is gained by holding it. The plugin only ever talks to the mount to
+ * answer a command, and the mount drops the link on its own shortly after it
+ * starts moving, so a cached connection is a dead one by the time the next
+ * command arrives: every command observed reusing one spent 13 to 29 seconds
+ * discovering a link that no longer existed before reconnecting anyway. A move
+ * carries on unattended once the write is acknowledged, so releasing right
+ * after costs nothing and lets the mount advertise again immediately.
  */
-async function resetPeripheral(log: Logging): Promise<void> {
+async function releasePeripheral(log: Logging, reason: string): Promise<void> {
   const peripheral = peripheralInstance ?? lastPeripheral;
   peripheralInstance = null;
   lastPeripheral = null;
   if (!peripheral) return;
 
-  log.info('[resetPeripheral] Dropping the cached peripheral');
+  log.info('[releasePeripheral]', reason);
   // Disconnecting one that is already down just hangs until the timeout.
   if (peripheral.state !== 'disconnected') {
     try {
@@ -188,7 +196,7 @@ async function resetPeripheral(log: Logging): Promise<void> {
         'Disconnect',
       );
     } catch (err) {
-      log.warn('[resetPeripheral] Failed to disconnect', toError(err).message);
+      log.warn('[releasePeripheral] Failed to disconnect', toError(err).message);
     }
   }
   forgetInNoble(peripheral);
@@ -199,8 +207,10 @@ async function getPeripheral(log: Logging): Promise<Peripheral> {
     log.info('[getPeripheral] Detecting peripheral ...');
     const peripheral = await detectFirstMotionMountPeripheral(log);
     peripheral.once('disconnect', () => {
+      // Stay quiet when we are the ones who just let go of it.
+      if (peripheralInstance !== peripheral) return;
       log.info('[getPeripheral] Peripheral disconnected, dropping it');
-      if (peripheralInstance === peripheral) peripheralInstance = null;
+      peripheralInstance = null;
     });
     peripheralInstance = peripheral;
     lastPeripheral = peripheral;
@@ -245,7 +255,7 @@ async function withRetry<T>(
       // Whatever failed, the link can no longer be trusted: start the next
       // attempt from a fresh discovery rather than piling requests onto a
       // half-dead connection.
-      await resetPeripheral(log);
+      await releasePeripheral(log, 'Dropping the connection after a failure');
       if (attempt < MAX_ATTEMPTS) {
         log.info(`[${label}] Retrying with a fresh connection`);
         await delay(RETRY_DELAY_MS);
@@ -303,9 +313,13 @@ export async function moveToPosition(
   log: Logging,
 ): Promise<void> {
   log.info('[moveToPosition] Going to', positionPreset.label);
-  await withRetry('moveToPosition', log, () =>
-    writePosition(positionPreset, log),
-  );
+  try {
+    await withRetry('moveToPosition', log, () =>
+      writePosition(positionPreset, log),
+    );
+  } finally {
+    await releasePeripheral(log, 'Move done, releasing the connection');
+  }
 }
 
 async function readPositionPresets(log: Logging): Promise<PositionPreset[]> {
@@ -361,7 +375,11 @@ export async function retrievePositionPresets(
   log: Logging,
 ): Promise<PositionPreset[]> {
   log.info('[retrievedStoredPositions] Starting the retrieval');
-  return withRetry('retrievedStoredPositions', log, () =>
-    readPositionPresets(log),
-  );
+  try {
+    return await withRetry('retrievedStoredPositions', log, () =>
+      readPositionPresets(log),
+    );
+  } finally {
+    await releasePeripheral(log, 'Presets read, releasing the connection');
+  }
 }

--- a/src/helper/motionMount.ts
+++ b/src/helper/motionMount.ts
@@ -9,13 +9,22 @@ const MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID =
 // forever and wedges every later call. These bounds exist to break that
 // deadlock, not to enforce responsiveness: a mount sitting at the edge of range
 // (a Raspberry Pi a few rooms away reports around -85 dBm) routinely needs 40s
-// just to connect, so they are deliberately loose.
-const SCAN_TIMEOUT_MS = 30_000;
+// just to connect, so they are deliberately loose. The scan is the loosest of
+// all: after a link dies the mount only advertises again once it notices, which
+// can take its whole supervision timeout, so a brief scan would miss a mount
+// that is about to come back.
+const SCAN_TIMEOUT_MS = 60_000;
 const CONNECT_TIMEOUT_MS = 90_000;
 const DISCONNECT_TIMEOUT_MS = 10_000;
 const DISCOVER_TIMEOUT_MS = 60_000;
 const READ_TIMEOUT_MS = 30_000;
 const WRITE_TIMEOUT_MS = 30_000;
+
+// A weak link drops mid-operation often enough that giving up on the first
+// failure loses moves the mount would happily have accepted a few seconds
+// later. Retry once, from a fresh discovery, after letting it advertise again.
+const MAX_ATTEMPTS = 2;
+const RETRY_DELAY_MS = 5_000;
 
 export interface PositionPreset {
   label: string;
@@ -28,9 +37,17 @@ export const WALL_POSITION: PositionPreset = {
 };
 
 let peripheralInstance: Peripheral | null;
+// The disconnect handler clears `peripheralInstance` on its own, which would
+// leave the cleanup below with nothing to work on. Keep the last peripheral we
+// talked to so a failed attempt can always tell noble to let go of it.
+let lastPeripheral: Peripheral | null;
 
 function toError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function withTimeout<T>(
@@ -51,6 +68,36 @@ async function withTimeout<T>(
     ]);
   } finally {
     clearTimeout(timer);
+  }
+}
+
+/**
+ * Bound a request by both a timeout and the life of the link. Once the mount is
+ * gone, waiting for the timeout only delays the retry: nothing can come back
+ * over a link that dropped, and a connection that dropped while being opened
+ * will never come up either.
+ */
+async function whileLinkHolds<T>(
+  peripheral: Peripheral,
+  request: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let onDisconnect: (() => void) | undefined;
+  const disconnected = new Promise<never>((_, reject) => {
+    onDisconnect = () =>
+      reject(new Error(`${label} aborted: the mount disconnected`));
+    peripheral.once('disconnect', onDisconnect);
+  });
+
+  try {
+    return await withTimeout(
+      Promise.race([request, disconnected]),
+      timeoutMs,
+      label,
+    );
+  } finally {
+    if (onDisconnect) peripheral.removeListener('disconnect', onDisconnect);
   }
 }
 
@@ -95,24 +142,56 @@ export async function detectFirstMotionMountPeripheral(
 }
 
 /**
+ * Drop noble's own cached objects for that peripheral.
+ *
+ * Abandoning a request — on a timeout or because the link dropped — only
+ * abandons the promise: noble keeps waiting for a reply that will never come,
+ * and every later request on that peripheral queues behind it for the lifetime
+ * of the process. noble reuses its cached peripheral on rediscovery, so the
+ * cache has to go for the next attempt to start from clean objects.
+ */
+function forgetInNoble(peripheral: Peripheral): void {
+  const caches = noble as unknown as Record<
+    string,
+    Record<string, unknown> | undefined
+  >;
+  for (const name of [
+    '_peripherals',
+    '_services',
+    '_characteristics',
+    '_descriptors',
+  ]) {
+    const cache = caches[name];
+    if (!cache) continue;
+    delete cache[peripheral.id];
+    delete cache[peripheral.uuid];
+  }
+}
+
+/**
  * Forget the cached peripheral so the next call rediscovers from scratch.
  * Disconnecting is best effort: the link is usually already gone by then.
  */
 async function resetPeripheral(log: Logging): Promise<void> {
-  const peripheral = peripheralInstance;
+  const peripheral = peripheralInstance ?? lastPeripheral;
   peripheralInstance = null;
+  lastPeripheral = null;
   if (!peripheral) return;
 
   log.info('[resetPeripheral] Dropping the cached peripheral');
-  try {
-    await withTimeout(
-      peripheral.disconnectAsync(),
-      DISCONNECT_TIMEOUT_MS,
-      'Disconnect',
-    );
-  } catch (err) {
-    log.warn('[resetPeripheral] Failed to disconnect', toError(err).message);
+  // Disconnecting one that is already down just hangs until the timeout.
+  if (peripheral.state !== 'disconnected') {
+    try {
+      await withTimeout(
+        peripheral.disconnectAsync(),
+        DISCONNECT_TIMEOUT_MS,
+        'Disconnect',
+      );
+    } catch (err) {
+      log.warn('[resetPeripheral] Failed to disconnect', toError(err).message);
+    }
   }
+  forgetInNoble(peripheral);
 }
 
 async function getPeripheral(log: Logging): Promise<Peripheral> {
@@ -124,6 +203,7 @@ async function getPeripheral(log: Logging): Promise<Peripheral> {
       if (peripheralInstance === peripheral) peripheralInstance = null;
     });
     peripheralInstance = peripheral;
+    lastPeripheral = peripheral;
     log.info('[getPeripheral] Peripheral detected');
   }
 
@@ -133,7 +213,8 @@ async function getPeripheral(log: Logging): Promise<Peripheral> {
   }
 
   log.info('[getPeripheral] Connecting ...');
-  await withTimeout(
+  await whileLinkHolds(
+    peripheralInstance,
     peripheralInstance.connectAsync(),
     CONNECT_TIMEOUT_MS,
     'Connect',
@@ -145,115 +226,142 @@ async function getPeripheral(log: Logging): Promise<Peripheral> {
   return peripheralInstance;
 }
 
+async function withRetry<T>(
+  label: string,
+  log: Logging,
+  action: () => Promise<T>,
+): Promise<T> {
+  let lastError = new Error(`[${label}] never ran`);
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await action();
+    } catch (err) {
+      lastError = toError(err);
+      log.error(
+        `[${label}] Attempt ${attempt}/${MAX_ATTEMPTS} failed:`,
+        lastError.message,
+      );
+      // Whatever failed, the link can no longer be trusted: start the next
+      // attempt from a fresh discovery rather than piling requests onto a
+      // half-dead connection.
+      await resetPeripheral(log);
+      if (attempt < MAX_ATTEMPTS) {
+        log.info(`[${label}] Retrying with a fresh connection`);
+        await delay(RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+async function writePosition(
+  positionPreset: PositionPreset,
+  log: Logging,
+): Promise<void> {
+  const peripheral = await getPeripheral(log);
+
+  log.info('[moveToPosition] Getting characteristics ...');
+  const { characteristics } = await whileLinkHolds(
+    peripheral,
+    peripheral.discoverSomeServicesAndCharacteristicsAsync(
+      [],
+      [MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID],
+    ),
+    DISCOVER_TIMEOUT_MS,
+    'Characteristic discovery',
+  );
+
+  // The macOS binding ignores the characteristic filter and returns the whole
+  // service, so never rely on the returned order: match the uuid explicitly.
+  const setPositionCharacteristic = characteristics.find(
+    ({ uuid }) => uuid === MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID,
+  );
+  if (!setPositionCharacteristic) {
+    throw new Error(
+      `Characteristic ${MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID} not found`,
+    );
+  }
+
+  // The characteristic only advertises `write` (with response); writing it
+  // without response is silently dropped by CoreBluetooth on macOS.
+  await whileLinkHolds(
+    peripheral,
+    setPositionCharacteristic.writeAsync(
+      Buffer.from(positionPreset.hexPosition, 'hex'),
+      false,
+    ),
+    WRITE_TIMEOUT_MS,
+    'Position write',
+  );
+  log.info('[moveToPosition] Position written');
+}
+
 export async function moveToPosition(
   positionPreset: PositionPreset,
   log: Logging,
 ): Promise<void> {
   log.info('[moveToPosition] Going to', positionPreset.label);
+  await withRetry('moveToPosition', log, () =>
+    writePosition(positionPreset, log),
+  );
+}
 
-  try {
-    const peripheral = await getPeripheral(log);
+async function readPositionPresets(log: Logging): Promise<PositionPreset[]> {
+  const peripheral = await getPeripheral(log);
+  const { characteristics } = await whileLinkHolds(
+    peripheral,
+    peripheral.discoverAllServicesAndCharacteristicsAsync(),
+    DISCOVER_TIMEOUT_MS,
+    'Service discovery',
+  );
+  // Omitting `2a00-2a05` retrieved by some devices
+  const normalizedCharacteristics = characteristics.filter(({ uuid }) =>
+    uuid.startsWith('c005fa'),
+  );
 
-    log.info('[moveToPosition] Getting characteristics ...');
-    const { characteristics } = await withTimeout(
-      peripheral.discoverSomeServicesAndCharacteristicsAsync(
-        [],
-        [MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID],
-      ),
-      DISCOVER_TIMEOUT_MS,
-      'Characteristic discovery',
+  const positionPresets: PositionPreset[] = [WALL_POSITION];
+  // Characteristics (#10-19 + #23-32) are the first part of the preset (+ 13 offset for the 2nd part)
+  const presetIndexOffset = 13;
+  const presetStartingIndex = 10;
+  const presetEndingIndex = 19;
+  for (
+    let index = presetStartingIndex;
+    index <= presetEndingIndex;
+    index += 1
+  ) {
+    const [presetPartOne, presetPartTwo] = await whileLinkHolds(
+      peripheral,
+      Promise.all([
+        normalizedCharacteristics[index].readAsync(),
+        normalizedCharacteristics[index + presetIndexOffset].readAsync(),
+      ]),
+      READ_TIMEOUT_MS,
+      `Preset #${index} read`,
     );
+    const presetHex =
+      presetPartOne.toString('hex') + presetPartTwo.toString('hex');
 
-    // The macOS binding ignores the characteristic filter and returns the whole
-    // service, so never rely on the returned order: match the uuid explicitly.
-    const setPositionCharacteristic = characteristics.find(
-      ({ uuid }) => uuid === MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID,
-    );
-    if (!setPositionCharacteristic) {
-      throw new Error(
-        `Characteristic ${MOTION_MOUNT_SET_POSITION_CHARACTERISTIC_UUID} not found`,
-      );
+    // First two chars for active/inactive preset (01: active, 00: inactive)
+    if (presetHex.slice(0, 2) === '01') {
+      positionPresets.push({
+        // 2-9 chars contain the position (2-5 hex signed wall distance and 6-9 hex signed orientation)
+        hexPosition: presetHex.slice(2, 10),
+        // 10-end contain the utf8 preset label
+        label: Buffer.from(presetHex.substring(10), 'hex').toString('utf8'),
+      });
     }
-
-    // The characteristic only advertises `write` (with response); writing it
-    // without response is silently dropped by CoreBluetooth on macOS.
-    await withTimeout(
-      setPositionCharacteristic.writeAsync(
-        Buffer.from(positionPreset.hexPosition, 'hex'),
-        false,
-      ),
-      WRITE_TIMEOUT_MS,
-      'Position write',
-    );
-    log.info('[moveToPosition] Position written');
-  } catch (err) {
-    const error = toError(err);
-    log.error('[moveToPosition]', error.message);
-    // Whatever failed, the link can no longer be trusted. Start over on the
-    // next call instead of piling requests onto a half-dead connection, and let
-    // the caller report the failure rather than pretending the mount moved.
-    await resetPeripheral(log);
-    throw error;
   }
+  log.info('[retrievedStoredPositions] #Presets found', positionPresets.length);
+  return positionPresets;
 }
 
 export async function retrievePositionPresets(
   log: Logging,
 ): Promise<PositionPreset[]> {
   log.info('[retrievedStoredPositions] Starting the retrieval');
-
-  try {
-    const peripheral = await getPeripheral(log);
-    const { characteristics } = await withTimeout(
-      peripheral.discoverAllServicesAndCharacteristicsAsync(),
-      DISCOVER_TIMEOUT_MS,
-      'Service discovery',
-    );
-    // Omitting `2a00-2a05` retrieved by some devices
-    const normalizedCharacteristics = characteristics.filter(({ uuid }) =>
-      uuid.startsWith('c005fa'),
-    );
-
-    const positionPresets: PositionPreset[] = [WALL_POSITION];
-    // Characteristics (#10-19 + #23-32) are the first part of the preset (+ 13 offset for the 2nd part)
-    const presetIndexOffset = 13;
-    const presetStartingIndex = 10;
-    const presetEndingIndex = 19;
-    for (
-      let index = presetStartingIndex;
-      index <= presetEndingIndex;
-      index += 1
-    ) {
-      const [presetPartOne, presetPartTwo] = await withTimeout(
-        Promise.all([
-          normalizedCharacteristics[index].readAsync(),
-          normalizedCharacteristics[index + presetIndexOffset].readAsync(),
-        ]),
-        READ_TIMEOUT_MS,
-        `Preset #${index} read`,
-      );
-      const presetHex =
-        presetPartOne.toString('hex') + presetPartTwo.toString('hex');
-
-      // First two chars for active/inactive preset (01: active, 00: inactive)
-      if (presetHex.slice(0, 2) === '01') {
-        positionPresets.push({
-          // 2-9 chars contain the position (2-5 hex signed wall distance and 6-9 hex signed orientation)
-          hexPosition: presetHex.slice(2, 10),
-          // 10-end contain the utf8 preset label
-          label: Buffer.from(presetHex.substring(10), 'hex').toString('utf8'),
-        });
-      }
-    }
-    log.info(
-      '[retrievedStoredPositions] #Presets found',
-      positionPresets.length,
-    );
-    return positionPresets;
-  } catch (err) {
-    const error = toError(err);
-    log.error('[retrievedStoredPositions]', error.message);
-    await resetPeripheral(log);
-    throw error;
-  }
+  return withRetry('retrievedStoredPositions', log, () =>
+    readPositionPresets(log),
+  );
 }

--- a/src/platform/MotionMountDynamicPlatform.ts
+++ b/src/platform/MotionMountDynamicPlatform.ts
@@ -77,45 +77,38 @@ export default class MotionMountDynamicPlatform implements DynamicPlatformPlugin
   private bindTvServiceHandlers(tvService: Service): void {
     tvService
       .getCharacteristic(this.hap.Characteristic.Active)
-      .onSet(async (active: CharacteristicValue): Promise<void> => {
+      .onSet((active: CharacteristicValue): void => {
         if (active) return;
-        await this.reportingFailureToHomeKit('[setActive]', () =>
-          this.moveToWall(tvService),
-        );
+        this.drive('[setActive]', () => this.moveToWall(tvService));
       });
 
     tvService
       .getCharacteristic(this.hap.Characteristic.ActiveIdentifier)
-      .onSet(async (index: CharacteristicValue): Promise<void> => {
+      .onSet((index: CharacteristicValue): void => {
         const positionPresets = this.tvAccessory?.context.positionPresets ?? [];
         const positionPreset = positionPresets[index as number];
         if (!positionPreset) {
           this.log.warn('[setActiveIdentifier] Unknown position preset', index);
           return;
         }
-        await this.reportingFailureToHomeKit('[setActiveIdentifier]', () =>
+        this.drive('[setActiveIdentifier]', () =>
           moveToPosition(positionPreset, this.log),
         );
       });
   }
 
   /**
-   * A Bluetooth move can fail for reasons the user can act on (mount out of
-   * range, adapter busy). Surface it in HomeKit instead of acknowledging a move
-   * that never happened.
+   * Acknowledge HomeKit straight away and drive the mount afterwards.
+   *
+   * Reaching a mount at the edge of Bluetooth range takes the best part of a
+   * minute, far longer than HomeKit waits for a write. Holding the request open
+   * only makes HomeKit give up, call it a failure and send the command again,
+   * piling up requests the mount cannot serve. Failures go to the log instead.
    */
-  private async reportingFailureToHomeKit(
-    context: string,
-    action: () => Promise<void>,
-  ): Promise<void> {
-    try {
-      await action();
-    } catch (err) {
+  private drive(context: string, action: () => Promise<void>): void {
+    void action().catch((err: unknown) => {
       this.log.error(context, err instanceof Error ? err.message : String(err));
-      throw new this.hap.HapStatusError(
-        this.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE,
-      );
-    }
+    });
   }
 
   private async moveToWall(tvService: Service): Promise<void> {

--- a/src/platform/MotionMountDynamicPlatform.ts
+++ b/src/platform/MotionMountDynamicPlatform.ts
@@ -79,7 +79,9 @@ export default class MotionMountDynamicPlatform implements DynamicPlatformPlugin
       .getCharacteristic(this.hap.Characteristic.Active)
       .onSet(async (active: CharacteristicValue): Promise<void> => {
         if (active) return;
-        await this.moveToWall(tvService);
+        await this.reportingFailureToHomeKit('[setActive]', () =>
+          this.moveToWall(tvService),
+        );
       });
 
     tvService
@@ -91,8 +93,29 @@ export default class MotionMountDynamicPlatform implements DynamicPlatformPlugin
           this.log.warn('[setActiveIdentifier] Unknown position preset', index);
           return;
         }
-        await moveToPosition(positionPreset, this.log);
+        await this.reportingFailureToHomeKit('[setActiveIdentifier]', () =>
+          moveToPosition(positionPreset, this.log),
+        );
       });
+  }
+
+  /**
+   * A Bluetooth move can fail for reasons the user can act on (mount out of
+   * range, adapter busy). Surface it in HomeKit instead of acknowledging a move
+   * that never happened.
+   */
+  private async reportingFailureToHomeKit(
+    context: string,
+    action: () => Promise<void>,
+  ): Promise<void> {
+    try {
+      await action();
+    } catch (err) {
+      this.log.error(context, err instanceof Error ? err.message : String(err));
+      throw new this.hap.HapStatusError(
+        this.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE,
+      );
+    }
   }
 
   private async moveToWall(tvService: Service): Promise<void> {


### PR DESCRIPTION
Follow-up to #349. Once the mount actually moved, a second failure mode showed up on a Raspberry Pi sitting at the edge of Bluetooth range (-92 dBm): after a while the plugin stopped responding to HomeKit entirely, with no error, until Homebridge was restarted.

### What happened

```
[MotionMount] [moveToPosition] Going to cuisine
[MotionMount] [getPeripheral] Connecting ...
[MotionMount] [getPeripheral] Connection established, rssi = -92
[MotionMount] [moveToPosition] Getting characteristics ...     <- never returns
[MotionMount] [moveToPosition] Going to Wall
[MotionMount] [getPeripheral] Already connected, returning as is
[MotionMount] [moveToPosition] Getting characteristics ...     <- never returns
```

At that exact moment `hcitool con` reported **no connection at all**, while the kernel logged `hci0: hcon ... sent 0 < count 1` in a loop — the ACL handle was half-open and could no longer carry anything.

Three things combined:

1. **The peripheral still reported `connected`.** `getPeripheral` trusted `state === 'connected'` and handed back a dead peripheral, so `Already connected, returning as is` sent every later request into the void.
2. **noble has no timeouts.** Those requests neither settled nor threw. The plugin stayed wedged indefinitely — a restart was the only way out.
3. **Errors were swallowed.** `moveToPosition` caught and logged, so even a genuine failure was reported to HomeKit as a success.

### Changes

- Every Bluetooth operation is bound by a timeout. They are deliberately loose — a connection alone routinely takes 40s at that range — because the point is to break deadlocks, not to enforce responsiveness.
- On any failure the cached peripheral is dropped, so the next call rediscovers from scratch instead of piling onto a half-dead link.
- The peripheral is also dropped as soon as noble reports it disconnected, via a `disconnect` listener.
- A timed-out scan stops scanning and unregisters its listener instead of leaving the adapter busy and starving the next attempt.
- `moveToPosition` and `retrievePositionPresets` reject instead of swallowing, and the platform maps that to `HAPStatus.SERVICE_COMMUNICATION_FAILURE` so HomeKit shows the move failed.

### Verification

Against a real Vogel's MotionMount on macOS:

| Scenario | Before | After |
|---|---|---|
| Link dropped behind the plugin's back, then a new move | hung forever | rediscovered, completed in 5.1s |
| Move while another process holds the mount (it stops advertising) | hung forever | rejected after 30s: `Scan timed out after 30000ms` |
| Normal move right after that timeout | — | works, no leftover state |

`pnpm build`, `pnpm typecheck` and `pnpm lint` pass.

### Note

This makes the plugin recover on its own, but it does not make a marginal link good. On the setup where this was found, `hci0` is shared between Home Assistant (BlueZ, scanning continuously) and this plugin (noble, raw HCI socket), which is worth avoiding — `NOBLE_HCI_DEVICE_ID` with a dedicated adapter is the documented way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)