### PR TITLE
:bug: Make GATT work when noble owns the adapter (HCI_CHANNEL_USER)

### DIFF
--- a/src/helper/motionMount.ts
+++ b/src/helper/motionMount.ts
@@ -34,6 +34,43 @@ const RETRY_DELAY_MS = 5_000;
 // binding negotiates its own parameters and ignores these.
 const CONNECTION_PARAMETERS = { timeout: 400 };
 
+// Setting HCI_CHANNEL_USER hands the adapter to noble and cuts BlueZ out of the
+// path, which takes the connect from ~42s to ~0.2s (measured on a Pi against a
+// mount at -90 dBm). On its own it also makes every GATT operation fail, and
+// the reason is a gap in noble 1.9.2-26 rather than a weak link: only the
+// raw-socket init (`pollIsDevUp`) asks the controller for its ACL buffer size.
+// The user-channel init runs a shorter sequence off the HCI reset that omits
+// `readLeBufferSize()`, so the promise `writeAclDataPkt()` awaits is never
+// resolved and every ATT PDU is swallowed before it reaches the socket. The
+// link connects, then sits idle until the mount hangs up ~46s later and the
+// operation reports "the mount disconnected".
+//
+// Ask for the buffer size ourselves once the adapter is up. Idempotent, and
+// scoped to the user channel: on the raw path noble has already asked, and on
+// macOS there is no HCI socket to ask through.
+type NobleHciInternals = {
+  _state?: string;
+  _bindings?: { _hci?: { readLeBufferSize?: () => void } };
+};
+
+function primeAclBuffers(): void {
+  (noble as unknown as NobleHciInternals)._bindings?._hci?.readLeBufferSize?.();
+}
+
+if (process.env.HCI_CHANNEL_USER) {
+  // The listener below is registered at import time, long before the adapter
+  // finishes coming up, so it normally does the work. Cover the case where
+  // noble is somehow already up and no further stateChange is coming.
+  if ((noble as unknown as NobleHciInternals)._state === 'poweredOn') {
+    primeAclBuffers();
+  }
+  noble.on('stateChange', (state: string) => {
+    if (state === 'poweredOn') {
+      primeAclBuffers();
+    }
+  });
+}
+
 type ConnectWithParameters = (
   parameters?: Record<string, number>,
 ) => Promise<void>;


### PR DESCRIPTION
Stacked on #350 — it needs that branch's timeout/retry work, and basing this on `master` would ship code that has not been run.

## What this unlocks

`HCI_CHANNEL_USER=1` hands the adapter to noble and cuts BlueZ out of the path. Measured on rpi-01 against a mount at -82/-92 dBm, on the real Homebridge container (not a bench harness):

| | discover → connected | full preset cycle |
|---|---|---|
| raw socket (BlueZ up) | 40–43 s | ~45 s |
| user channel | **205 ms** | **3.6 s** |

The 42 s sits entirely inside `peripheral.connectAsync()`. It is not signal strength: raw connects in 42.5 s at -94 dBm, user channel in 205 ms at -82 dBm.

## Why the flag alone does not work

Turning it on makes every GATT operation fail with `Service discovery aborted: the mount disconnected`, which reads like a weak link. It is not. In `@abandonware/noble` 1.9.2-26 only the raw-socket init (`pollIsDevUp`) asks the controller for its ACL buffer size:

```js
this.readLocalVersion(); this.writeLeHostSupported();
this.readLeHostSupported(); this.readLeBufferSize(); this.readBdAddr();
```

The user-channel init runs a shorter sequence off the HCI reset (`processCmdCompleteEvent`, `RESET_CMD` branch) that omits it:

```js
this.readLocalVersion(); this.readBdAddr();
```

`writeAclDataPkt()` opens with `await this.getAclBuffers()`. Without that call `_aclBuffers` is never set, the promise never resolves, and **every ATT PDU is swallowed before it reaches the socket**. Under `DEBUG=hci,att` the signature is an `att write:` with no `push to acl queue` behind it. The link connects, sits idle, and the mount hangs up ~46 s later.

Asking for the buffer size ourselves once the adapter is up fixes it — verified with **stock noble**, no dependency patching:

```
le buffer size: length = 27, num = 8
att ...: new MTU is 23
[retrievedStoredPositions] #Presets found 6
```

## Scope

Guarded on `process.env.HCI_CHANNEL_USER`, so nothing changes on the raw path (noble has already asked) or on macOS (no HCI socket). Reaching into `_bindings._hci` is not pretty; the real fix belongs upstream and I am happy to send it there too.

## Known follow-up, deliberately not in this PR

In user-channel mode the **first** attempt after startup always fails with `Could not start scanning, state is unknown (not poweredOn)` — the platform starts scanning before noble finishes its init. #350's retry recovers it 5 s later, so it is invisible in practice. Awaiting `poweredOn` before the first scan would remove that penalty, but it is a separate change and unvalidated, so it is not bundled here.

## Operational caveat for whoever deploys this

The user channel makes the adapter **exclusive** — BlueZ gets nothing, and `bluetoothd` must be kept from powering it (`AutoEnable=false`), otherwise `bindUser()` fails with `EBUSY`.

Separately, on a TP-Link UB500 (RTL8761BU) every transition in and out of the user channel triggered `command tx timeout` → kernel USB reset → the adapter reappearing as `hci1`, and index 0 stays pinned until a reboot. If you pin `NOBLE_HCI_DEVICE_ID`, that breaks the plugin until the host restarts. Leaving it unset is safer: the native binding's `devIdFor()` auto-selects the sole adapter whatever its index (verified on `hci1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)