### PR TITLE
:bookmark: Prepare the v2.0.0-alpha.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,21 @@ jobs:
       - name: Build output 🛠
         run: pnpm build
 
+      # A prerelease published without an explicit dist-tag lands on `latest`,
+      # which would hand it to every existing install on its next update.
+      # `2.0.0-alpha.0` goes out as `alpha`, `2.0.0` as `latest`.
+      - name: Resolve the dist-tag 🏷
+        id: dist-tag
+        run: |
+          version=$(node -p "require('./package.json').version")
+          prerelease=${version#*-}
+          if [ "$prerelease" = "$version" ]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${prerelease%%.*}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm 🚀
-        run: npm publish --provenance --access public --ignore-scripts
+        run: npm publish --provenance --access public --ignore-scripts --tag ${{ steps.dist-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@
 
 > Unofficial Homebridge plugin for a basic support of Vogel's motion mount. This plugin will add a Television with inputs corresponding to the position presets stored on the mount with the official app.
 
+> [!WARNING]
+> `v2` is in **alpha**. It targets Homebridge 2.x and Node.js 22/24, and it is published under the `alpha` dist-tag: `latest` stays on `v1.2.0`, so existing installs are left alone until you opt in. See [Breaking changes](#breaking-changes).
+
 ### Install
 
 ```bash
+# stable
 npm install -g homebridge-vogels-motionmount
+
+# v2 alpha
+npm install -g homebridge-vogels-motionmount@alpha
 ```
 
 ### Usage
@@ -28,28 +35,47 @@ Position presets are retrieved at the startup:
 
 ![Alt text](screens/motionmount-app.png?raw=true 'Motion mount official app') ![Alt text](screens/tv-accessory.png?raw=true 'TV accessory')
 
-### Legal
-
-Vogels is a registered trademarks of Vogel's Products S.A.R.L.
-
-This project is in no way affiliated with, authorized, maintained, sponsored or endorsed by Vogels or any of its affiliates or subsidiaries.
-
-### Raspberry PI bluetooth connection issues
-
-Like many others I encountered disconnection issues with the builtin bluetooth of raspberry Pi 3/4 (@see [noble/issues/465](https://github.com/noble/noble/issues/465) and [abandonware/noble/issues/99](https://github.com/abandonware/noble/issues/99) for eg). If you use this device with an external bluetooth device do not forget to set `NOBLE_HCI_DEVICE_ID` env var accordingly (more at https://github.com/abandonware/noble#multiple-adapters-linux-specific).
-
-### Breaking changes
-
-`v2.x.x` requires Homebridge `^2.0.0` and Node.js `^22` or `^24`. Stay on `v1.2.0` if you are still running Homebridge 1.x.
-
-`v1.x.x` is not backward compatible with `v0.x.x`. Last versions use a TV accessory where `v0.x.x` use switches.
-
-Prior to `v1.1.0` upgrading from `v0.x.x` to `v1.x.x` require to remove the `~/.homebridge/persist` (or `Menu -> Help -> Reset Connection` with Hoobs).
-
 ### Requirements
 
 - Node.js `^22` or `^24`
 - Homebridge `^2.0.0`
+
+### Bluetooth
+
+The mount is a BLE peripheral, and the plugin only talks to it to answer a command: it scans, connects, writes, then lets go. Nothing is kept open between commands — the mount drops the link on its own shortly after it starts moving, so a cached connection is a dead one by the time the next command arrives.
+
+Commands are also serialised and retried once from a fresh discovery, and HomeKit is acknowledged straight away rather than kept waiting: reaching a mount at the edge of range takes far longer than HomeKit waits for a write, and holding the request open only made it give up and send the command again. **Failures therefore land in the Homebridge log, not in the Home app** — check the log if a move does not happen.
+
+#### Handing the adapter to noble (`HCI_CHANNEL_USER`)
+
+On Linux, going through BlueZ is slow once the mount is far from the host. Setting `HCI_CHANNEL_USER=1` in the Homebridge environment hands the adapter to noble and cuts BlueZ out of the path. Measured on a Raspberry Pi against a mount at -82/-92 dBm:
+
+|                        | via BlueZ | user channel |
+| ---------------------- | --------- | ------------ |
+| discover → connected   | 42s       | 205ms        |
+| full preset read cycle | ~45s      | 3.6s         |
+
+It is worth it, with strings attached:
+
+- the adapter must be **down** (`sudo hciconfig hci0 down`) before the process binds it — the kernel refuses the user channel otherwise;
+- while it is bound, BlueZ cannot use that adapter: `bluetoothctl` and any other Bluetooth plugin sharing it stop working. Use a second adapter if you need both;
+- it needs `CAP_NET_ADMIN` (run as root, or `sudo setcap cap_net_raw,cap_net_admin+eip $(readlink -f $(which node))`).
+
+Left unset, the plugin keeps using the regular BlueZ path.
+
+#### Raspberry Pi connection issues
+
+Like many others I encountered disconnection issues with the builtin bluetooth of Raspberry Pi 3/4 (@see [noble/issues/465](https://github.com/noble/noble/issues/465) and [abandonware/noble/issues/99](https://github.com/abandonware/noble/issues/99) for eg). If you use this device with an external bluetooth device do not forget to set `NOBLE_HCI_DEVICE_ID` env var accordingly (more at https://github.com/abandonware/noble#multiple-adapters-linux-specific).
+
+`v2` makes a weak link far less painful on its own: it asks for a 4s supervision timeout instead of noble's hardcoded 420ms, which used to tear the link down the moment discovery started at -86 dBm.
+
+### Breaking changes
+
+`v2.x.x` requires Homebridge `^2.0.0` and Node.js `^22` or `^24`. Stay on `v1.2.0` if you are still running Homebridge 1.x. Beyond the platform bump, it reworks the Bluetooth layer: no connection is reused between commands, commands are serialised and retried, superseded moves are dropped, and command failures are reported in the log rather than to HomeKit.
+
+`v1.x.x` is not backward compatible with `v0.x.x`. Last versions use a TV accessory where `v0.x.x` use switches.
+
+Prior to `v1.1.0` upgrading from `v0.x.x` to `v1.x.x` require to remove the `~/.homebridge/persist` (or `Menu -> Help -> Reset Connection` with Hoobs).
 
 ### Development
 
@@ -62,11 +88,19 @@ pnpm lint
 pnpm build
 ```
 
+Set `DEBUG=hci,att` to trace what noble exchanges with the mount.
+
 ### Release
 
-Tagging a `v*` commit triggers the `Release` workflow, which builds and publishes to npm.
+Tagging a `v*` commit triggers the `Release` workflow, which builds and publishes to npm. The dist-tag is derived from the version: `2.0.0-alpha.0` is published as `alpha`, `2.0.0` as `latest`.
 
 ```bash
-pnpm version <major|minor|patch>
+pnpm version <major|minor|patch|prerelease>
 git push --follow-tags
 ```
+
+### Legal
+
+Vogels is a registered trademarks of Vogel's Products S.A.R.L.
+
+This project is in no way affiliated with, authorized, maintained, sponsored or endorsed by Vogels or any of its affiliates or subsidiaries.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-vogels-motionmount",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:howm/homebridge-vogels-motionmount.git",
@@ -9,7 +9,12 @@
   "license": "MIT",
   "private": false,
   "keywords": [
-    "homebridge-plugin"
+    "homebridge-plugin",
+    "homebridge",
+    "vogels",
+    "motionmount",
+    "bluetooth",
+    "ble"
   ],
   "files": [
     "dist"


### PR DESCRIPTION
Prepares the first published release of the Bluetooth rework, as an alpha.

### Version

`2.0.0-alpha.0`. `latest` on npm is still `1.2.0` — the `2.0.0` that sat in `package.json` was never published, so there is no intermediate release to migrate from.

### Keeping `latest` on v1.2.0

`npm publish` puts a prerelease on the `latest` dist-tag like any other version, so publishing the alpha as it stood would have handed it to every existing install on its next update. The `Release` workflow now derives the dist-tag from the version:

- `2.0.0-alpha.0` → `alpha`
- `2.0.0` → `latest`

### README

Documents what actually changed underneath, none of which was written down:

- no connection is reused between commands, commands are serialised and retried once from a fresh discovery, and superseded moves are dropped;
- failures land in the Homebridge log rather than in the Home app, since HomeKit is acknowledged straight away;
- `HCI_CHANNEL_USER` gets a section of its own — 42s → 205ms to connect on a Pi, with the three constraints that come with it (adapter down, BlueZ locked out of it, `CAP_NET_ADMIN`);
- the `v2.x.x` breaking-changes entry covers the Bluetooth rework, not just the Homebridge 2.x / Node 22-24 bump.

### After merge

Tag `v2.0.0-alpha.0` on master and push it to trigger the `Release` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)